### PR TITLE
 Remove unnecessary error log while adding the workflow definitions

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.impl/src/main/resources/templates/bpel/MultiStepApprovalService/ApprovalProcess.bpel
+++ b/components/org.wso2.carbon.identity.workflow.impl/src/main/resources/templates/bpel/MultiStepApprovalService/ApprovalProcess.bpel
@@ -46,13 +46,7 @@
 	        importType="http://schemas.xmlsoap.org/wsdl/" />
 	
 	
-	
-	<!-- BPEL4People extension activity -->
-    <extensions>
-        <extension
-                namespace="http://docs.oasis-open.org/ns/bpel4people/bpel4people/200803"
-                mustUnderstand="yes"/>
-    </extensions>
+
 	        
     <!-- ================================================================= -->         
     <!-- PARTNERLINKS                                                      -->
@@ -301,7 +295,7 @@
       <p:outcome part="" queryLanguage="http://tempuri.org">
         <p:documentation p:lang=""></p:documentation>
       </p:outcome>
-      <p:searchBy expressionLanguage="http://tempuri.org" xsi:type="p:tExpression">
+      <p:searchBy expressionLanguage="http://tempuri.org" type="p:tExpression">
         <p:documentation p:lang=""></p:documentation>
       </p:searchBy>
       <p:renderings>


### PR DESCRIPTION
### Description
Fix the issue of logging an error in wso2carbon log when adding a Workflow Definitions.
- Public fix of https://github.com/wso2-support/identity-workflow-impl-bps/pull/12
- Resolves: https://github.com/wso2/product-is/issues/9611

### Approach
The error log was due to an invalid content added as an extension. Therefore remove that error log and update type definition of an element.