### PR TITLE
Increase the length of username input for registering WF engine

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.impl.ui/src/main/resources/web/workflow-impl/add-bps-profile.jsp
+++ b/components/org.wso2.carbon.identity.workflow.impl.ui/src/main/resources/web/workflow-impl/add-bps-profile.jsp
@@ -119,7 +119,7 @@
                             <span class="required">*</span>
                         </td>
                         <td><input type="text" name="<%=WorkflowUIConstants.PARAM_BPS_AUTH_USER%>"
-                                   label="<fmt:message key='workflow.bps.profile.auth.user'/>" maxlength="45"
+                                   label="<fmt:message key='workflow.bps.profile.auth.user'/>" maxlength="75"
                                    black-list-patterns="^(\s*)$" style="width:30%" class="text-box-big"/></td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Purpose
Fix: wso2/product-is#9947

- Increase the input field length of the username field when registering workflow engine from the management console.

### When should this PR be merged

Now

Has a dependency to https://github.com/wso2/carbon-identity-framework/pull/3271