### PR TITLE
Upgrade SSL context protocol to TLSv1.2

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/util/SSLContextFactory.java
+++ b/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/util/SSLContextFactory.java
@@ -66,7 +66,7 @@ public class SSLContextFactory {
     /**
      * Default ssl protocol for client
      */
-    private static final String protocol = "TLSv1";
+    private static final String protocol = "TLSv1.2";
 
     public static SSLContext getSslContext() throws WorkflowImplException {
         if (sslContext == null) {


### PR DESCRIPTION
The SSL context protocol should be upgraded to a more secure protocol to fix "Selection of Less-Secure Algorithm During Negotiation" security vulnerabilities.