### PR TITLE
Java 11 build support

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.impl.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.workflow.impl.ui/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.workflow.impl.ui/pom.xml
+++ b/components/org.wso2.carbon.identity.workflow.impl.ui/pom.xml
@@ -63,6 +63,11 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core.ui</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
                 <artifactId>axiom</artifactId>
                 <version>${axiom.wso2.version}</version>
             </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.api.version}</version>
+            </dependency>
 
             <!-- Pax Logging -->
             <dependency>
@@ -282,6 +287,7 @@
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 
+        <jaxb.api.version>2.3.0</jaxb.api.version>
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
     </properties>


### PR DESCRIPTION
### Proposed changes in this pull request

According to the [release-notes](https://www.oracle.com/java/technologies/javase/11-relnote-issues.html#JDK-8190378), Java 11 removed the Java EE modules:

```
java.xml.bind (JAXB) - REMOVED
```

Hence we have to add Maven dependencies that contain the classes in order to provide the Java 11 build support.