### PR TITLE
Bump framework version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
 
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>
 
-        <identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</identity.framework.imp.pkg.version.range>
+        <identity.framework.imp.pkg.version.range>[5.14.67, 8.0.0)</identity.framework.imp.pkg.version.range>
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.identity.workflow.impl.bps.import.version.range>[5.3.0, 6.0.0)
@@ -405,7 +405,7 @@
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
 
-        <carbon.identity.package.import.version.range>[5.14.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[5.14.0, 8.0.0)</carbon.identity.package.import.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,2.2.0)</org.wso2.carbon.database.utils.version.range>
 


### PR DESCRIPTION
Bump framework version range to 7.x.x to support IS 7.0

Related to https://github.com/wso2/product-is/issues/19757