### PR TITLE
Update the workflow request builder compatible for the BPS

### DIFF
--- a/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/WFImplConstant.java
+++ b/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/WFImplConstant.java
@@ -49,10 +49,6 @@ public class WFImplConstant {
         public static final String HT_SUBJECT = "HTSubject";
         public static final String HT_DESCRIPTION = "HTDescription";
 
-        public static final String UPDATED_STEPS_USER_AND_ROLE = "ApprovalSteps";
-        public static final String APPROVAL_STEPS_SEPARATOR = "Step-";
-
-
     }
     public static final String DEFAULT_APPROVAL_BPEL_SOAP_ACTION = "http://bpel.mgt.workflow.carbon.wso2" +
                                                                    ".org/approvalProcess/initiate";

--- a/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/WFImplConstant.java
+++ b/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/WFImplConstant.java
@@ -49,6 +49,10 @@ public class WFImplConstant {
         public static final String HT_SUBJECT = "HTSubject";
         public static final String HT_DESCRIPTION = "HTDescription";
 
+        public static final String UPDATED_STEPS_USER_AND_ROLE = "ApprovalSteps";
+        public static final String APPROVAL_STEPS_SEPARATOR = "Step-";
+
+
     }
     public static final String DEFAULT_APPROVAL_BPEL_SOAP_ACTION = "http://bpel.mgt.workflow.carbon.wso2" +
                                                                    ".org/approvalProcess/initiate";

--- a/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/util/WorkflowRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/util/WorkflowRequestBuilder.java
@@ -69,6 +69,9 @@ public class WorkflowRequestBuilder {
     private static final String WF_REQ_KEY_ATTRIB = "itemName";
     private static final String WF_REQ_VALUE_ELEM = "value";
 
+    private static final String UPDATED_KEY_FOR_STEPS_USER_AND_ROLE = "ApprovalSteps";
+    private static final String APPROVAL_STEPS_SEPARATOR = "Step-";
+
     private static final Set<Class> SUPPORTED_CLASS_TYPES;
 
     static {
@@ -144,13 +147,14 @@ public class WorkflowRequestBuilder {
                                                                            workFlowRequest.getEventType());
 
         for (Parameter parameter : parameterList) {
-            if (parameter.getParamName().equals(WFImplConstant.ParameterName.UPDATED_STEPS_USER_AND_ROLE)) {
+            if (parameter.getParamName().equals(UPDATED_KEY_FOR_STEPS_USER_AND_ROLE)) {
                 parameter.setParamName(WFImplConstant.ParameterName.STEPS_USER_AND_ROLE);
                 String qName = parameter.getqName();
-                if (qName != null && qName.startsWith(WFImplConstant.ParameterName.APPROVAL_STEPS_SEPARATOR)) {
-                    qName = qName.replace(WFImplConstant.ParameterName.APPROVAL_STEPS_SEPARATOR,
+                if (qName != null && qName.startsWith(APPROVAL_STEPS_SEPARATOR)) {
+                    qName = qName.replace(APPROVAL_STEPS_SEPARATOR,
                             WFImplConstant.ParameterName.STEPS_USER_AND_ROLE + "-step-");
-                    parameter.setqName(qName);                }
+                    parameter.setqName(qName);
+                }
             }
         }
 

--- a/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/util/WorkflowRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.workflow.impl/src/main/java/org/wso2/carbon/identity/workflow/impl/util/WorkflowRequestBuilder.java
@@ -143,6 +143,17 @@ public class WorkflowRequestBuilder {
         WorkflowRequestBuilder requestBuilder = new WorkflowRequestBuilder(workFlowRequest.getUuid(),
                                                                            workFlowRequest.getEventType());
 
+        for (Parameter parameter : parameterList) {
+            if (parameter.getParamName().equals(WFImplConstant.ParameterName.UPDATED_STEPS_USER_AND_ROLE)) {
+                parameter.setParamName(WFImplConstant.ParameterName.STEPS_USER_AND_ROLE);
+                String qName = parameter.getqName();
+                if (qName != null && qName.startsWith(WFImplConstant.ParameterName.APPROVAL_STEPS_SEPARATOR)) {
+                    qName = qName.replace(WFImplConstant.ParameterName.APPROVAL_STEPS_SEPARATOR,
+                            WFImplConstant.ParameterName.STEPS_USER_AND_ROLE + "-step-");
+                    parameter.setqName(qName);                }
+            }
+        }
+
         for (RequestParameter parameter : workFlowRequest.getRequestParameters()) {
             if (parameter.isRequiredInWorkflow()) {
                 switch (parameter.getValueType()) {


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

- ### Related Issues
- https://github.com/wso2/product-is/issues/25774


The workflow parameters were updated with the new workflow implementation as follows.

<img width="566" height="637" alt="Screenshot 2025-10-09 at 00 05 03" src="https://github.com/user-attachments/assets/6b2c36ec-8b0c-4f70-97db-3dad5d846f64" />


With this PR, the "ApprovalSteps" parameter is renamed to the previously BPS supported parameter name "UserAndRole" and the `qName` also updated to the BPS supported format as shown below.

<img width="463" height="584" alt="Screenshot 2025-10-09 at 00 32 53" src="https://github.com/user-attachments/assets/2c516c3b-7888-4a39-aabb-20f0a8734fcf" />


The update only affect for the communication between IS and BPS.